### PR TITLE
Harden hybrid retrieval, batching, and MCP result formatting

### DIFF
--- a/packages/core/src/Calculators/EmbeddingCalculator.py
+++ b/packages/core/src/Calculators/EmbeddingCalculator.py
@@ -5,7 +5,7 @@ from typing import Optional
 import numpy as np
 from sentence_transformers import SentenceTransformer
 
-from constants import EMBEDDING_DIMENSIONS, EMBEDDING_MODEL_ID
+from constants import EMBEDDING_BATCH_SIZE, EMBEDDING_DIMENSIONS, EMBEDDING_MODEL_ID
 
 logger = logging.getLogger(__name__)
 
@@ -75,17 +75,21 @@ class EmbeddingCalculator:
 
     def calculate_batch(self, chunks: list[str]) -> list[bytes]:
         assert self._model is not None
-        vecs = self._model.encode(
-            chunks,
-            normalize_embeddings=True,
-            batch_size=len(chunks),
-            show_progress_bar=False,
-        )
-        results = []
-
-        for vec in vecs:
-            arr = np.asarray(vec, dtype=np.float32).reshape(-1)
-            if arr.shape[0] != EMBEDDING_DIMENSIONS:
-                raise ValueError(f"Unexpected embedding dimension {arr.shape[0]}")
-            results.append(arr.tobytes())
+        if not chunks:
+            return []
+        batch_size = max(1, min(EMBEDDING_BATCH_SIZE, len(chunks)))
+        results: list[bytes] = []
+        for start in range(0, len(chunks), batch_size):
+            window = chunks[start : start + batch_size]
+            vecs = self._model.encode(
+                window,
+                normalize_embeddings=True,
+                batch_size=batch_size,
+                show_progress_bar=False,
+            )
+            for vec in vecs:
+                arr = np.asarray(vec, dtype=np.float32).reshape(-1)
+                if arr.shape[0] != EMBEDDING_DIMENSIONS:
+                    raise ValueError(f"Unexpected embedding dimension {arr.shape[0]}")
+                results.append(arr.tobytes())
         return results

--- a/packages/core/src/Persistence/Persist.py
+++ b/packages/core/src/Persistence/Persist.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import math
+import re
 from array import array
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Protocol, Sequence
@@ -209,58 +210,47 @@ class PersistInLibsql(PersistenceAdapter):
             repo=repo,
             branch=branch,
         )
-        if not keyword_rows:
-            return []
-
-        # Optimization: calculate vector similarities in batch using numpy
         query_vec = np.asarray(query_embedding, dtype=np.float32).reshape(-1)
         query_norm = np.linalg.norm(query_vec)
         if query_norm > 1e-9:
             query_vec = query_vec / query_norm
+        vector_rows = self._vector_search(
+            query_embedding=query_vec,
+            limit=normalized_limit * 5,
+            repo=repo,
+            branch=branch,
+        )
+        if not keyword_rows and not vector_rows:
+            return []
 
-        candidate_embeddings = []
+        merged: Dict[str, Dict[str, Any]] = {}
         for row in keyword_rows:
-            raw = row.get("embedding")
-            if raw is not None:
-                vec = np.frombuffer(bytes(raw), dtype=np.float32)
-                candidate_embeddings.append(vec)
+            merged[row["id"]] = row
+        for row in vector_rows:
+            existing = merged.get(row["id"])
+            if existing is None:
+                merged[row["id"]] = row
             else:
-                candidate_embeddings.append(np.zeros_like(query_vec))
-        
-        matrix = np.stack(candidate_embeddings)
-        row_norms = np.linalg.norm(matrix, axis=1, keepdims=True)
-        # Avoid division by zero
-        matrix_normalized = matrix / np.where(row_norms > 1e-9, row_norms, 1.0)
-        
-        vector_scores = np.dot(matrix_normalized, query_vec)
-        
-        # Hybrid scoring using Reciprocal Rank Fusion (RRF) for robustness
-        # across different score scales (BM25 vs Cosine Similarity).
-        
-        # 1. Rank by vector score
-        vector_ranked = sorted(range(len(keyword_rows)), key=lambda i: vector_scores[i], reverse=True)
-        vector_ranks = {idx: rank for rank, idx in enumerate(vector_ranked)}
-        
-        # 2. Rank by keyword score (they are already sorted by SQLite, but let's be explicit)
-        keyword_ranked = sorted(range(len(keyword_rows)), key=lambda i: float(keyword_rows[i].get("keyword_score") or 0.0), reverse=True)
-        keyword_ranks = {idx: rank for rank, idx in enumerate(keyword_ranked)}
-        
-        rrf_k = 60 # Standard constant for RRF
-        scored = []
-        for i, row in enumerate(keyword_rows):
-            v_rank = vector_ranks[i]
-            k_rank = keyword_ranks[i]
-            
-            # RRF score formula
-            rrf_score = (1.0 / (rrf_k + v_rank)) + (1.0 / (rrf_k + k_rank))
-            scored.append((rrf_score, row))
+                if existing.get("embedding") is None and row.get("embedding") is not None:
+                    existing["embedding"] = row["embedding"]
+                existing["vector_score"] = row.get("vector_score", 0.0)
 
+        candidates = list(merged.values())
+        keyword_ranked = sorted(range(len(candidates)), key=lambda i: float(candidates[i].get("keyword_score") or 0.0), reverse=True)
+        vector_ranked = sorted(range(len(candidates)), key=lambda i: float(candidates[i].get("vector_score") or 0.0), reverse=True)
+        keyword_ranks = {idx: rank for rank, idx in enumerate(keyword_ranked)}
+        vector_ranks = {idx: rank for rank, idx in enumerate(vector_ranked)}
+        rrf_k = 60
+        scored = []
+        for i, row in enumerate(candidates):
+            rrf_score = (1.0 / (rrf_k + keyword_ranks[i])) + (1.0 / (rrf_k + vector_ranks[i]))
+            scored.append((rrf_score, row))
         scored.sort(key=lambda item: item[0], reverse=True)
         return [self._row_to_chunk(row) for _, row in scored[:normalized_limit]]
 
     @staticmethod
     def _vector_similarity(v1: Sequence[float], v2_bytes: bytes | None) -> float:
-        if not v2_bytes or not v1:
+        if not v2_bytes or len(v1) == 0:
             return 0.0
         try:
             arr1 = np.asarray(v1, dtype=np.float32)
@@ -379,10 +369,13 @@ class PersistInLibsql(PersistenceAdapter):
 
         extra = (" AND " + " AND ".join(filter_clauses)) if filter_clauses else ""
 
+        safe_query = self._safe_fts_query(query)
+
         fts_sql = text(
             f"SELECT c.id, c.repo, c.branch, c.path, c.language, c.start_row, c.start_col, "
             f"c.end_row, c.end_col, c.start_bytes, c.end_bytes, c.chunk, c.embedding, "
-            f"-bm25({self._fts_table}) AS keyword_score "
+            f"-bm25({self._fts_table}) AS keyword_score, "
+            f"0.0 AS vector_score "
             f"FROM {self._fts_table} AS f "
             f"JOIN {self._table} AS c ON c.id = f.id "
             f"WHERE f.chunk MATCH :query{extra} "
@@ -399,16 +392,17 @@ class PersistInLibsql(PersistenceAdapter):
         fallback_sql = text(
             f"SELECT id, repo, branch, path, language, start_row, start_col, end_row, end_col, "
             f"start_bytes, end_bytes, chunk, embedding, "
-            f"CASE WHEN lower(chunk) LIKE lower(:term) THEN 1 ELSE 0 END AS keyword_score "
+            f"CASE WHEN lower(chunk) LIKE lower(:term) THEN 1 ELSE 0 END AS keyword_score, "
+            f"0.0 AS vector_score "
             f"FROM {self._table} "
             f"WHERE lower(chunk) LIKE lower(:term){fallback_extra} "
             f"ORDER BY keyword_score DESC LIMIT :limit"
         )
 
         with self._engine.connect() as conn:
-            if query:
+            if safe_query:
                 try:
-                    rows = conn.execute(fts_sql, {**params, "query": query}).mappings().all()
+                    rows = conn.execute(fts_sql, {**params, "query": safe_query}).mappings().all()
                     if rows:
                         return [dict(row) for row in rows]
                 except Exception:
@@ -417,6 +411,45 @@ class PersistInLibsql(PersistenceAdapter):
             term = f"%{query}%" if query else "%"
             rows = conn.execute(fallback_sql, {**params, "term": term}).mappings().all()
         return [dict(row) for row in rows]
+
+    @staticmethod
+    def _safe_fts_query(query: str) -> str:
+        terms = [part.strip() for part in re.findall(r"[A-Za-z0-9_]+", query or "") if part.strip()]
+        if not terms:
+            return ""
+        return " OR ".join(f'"{term}"' for term in terms)
+
+    def _vector_search(
+        self,
+        *,
+        query_embedding: np.ndarray,
+        limit: int,
+        repo: str | None = None,
+        branch: str | None = None,
+    ) -> List[Dict[str, Any]]:
+        params: Dict[str, Any] = {}
+        filters = []
+        if repo is not None:
+            filters.append("repo = :repo")
+            params["repo"] = repo
+        if branch is not None:
+            filters.append("branch = :branch")
+            params["branch"] = branch
+        where_clause = f" WHERE {' AND '.join(filters)}" if filters else ""
+        sql = text(
+            f"SELECT id, repo, branch, path, language, start_row, start_col, end_row, end_col, "
+            f"start_bytes, end_bytes, chunk, embedding FROM {self._table}{where_clause}"
+        )
+        with self._engine.connect() as conn:
+            rows = conn.execute(sql, params).mappings().all()
+        scored: List[Dict[str, Any]] = []
+        for row in rows:
+            row_dict = dict(row)
+            row_dict["keyword_score"] = 0.0
+            row_dict["vector_score"] = self._vector_similarity(query_embedding, row_dict.get("embedding"))
+            scored.append(row_dict)
+        scored.sort(key=lambda item: float(item.get("vector_score") or 0.0), reverse=True)
+        return scored[:limit]
 
 
     @staticmethod

--- a/packages/core/src/Retriever.py
+++ b/packages/core/src/Retriever.py
@@ -13,8 +13,10 @@ from Persistence.Persist import PersistenceAdapter
 from constants import (
     DEFAULT_ATTN_IMPLEMENTATION,
     DEFAULT_INITIAL_RETRIEVAL_LIMIT,
+    MAX_INITIAL_RETRIEVAL_LIMIT,
     DEFAULT_RERANK_TASK_INSTRUCTION,
     DEFAULT_RERANKER_MODEL,
+    RERANK_BATCH_SIZE,
     RETRIEVAL_QUERY_PREFIX,
 )
 
@@ -47,6 +49,7 @@ class Qwen3Reranker:
         self._model_name = model_name
         self._task_instruction = task_instruction or DEFAULT_RERANK_TASK_INSTRUCTION
         self._attn_implementation = attn_implementation
+        self._batch_size = max(1, RERANK_BATCH_SIZE)
         self._ensure_loaded(model_name=model_name, attn_implementation=attn_implementation)
 
     @classmethod
@@ -112,24 +115,31 @@ class Qwen3Reranker:
             )
             for candidate in candidates
         ]
-        encoded = tokenizer(
-            pairs,
-            padding=True,
-            truncation=True,
-            max_length=512,
-            return_tensors="pt"
-        )
         import torch
 
-        with torch.inference_mode():
-            outputs = model(**encoded)
-        logits = getattr(outputs, "logits", None)
-        if logits is None:
-            return [0.0 for _ in candidates]
-        flat = logits.squeeze(-1).detach().cpu().tolist()
-        if isinstance(flat, float):
-            return [flat]
-        return [float(v) for v in flat]
+        all_scores: list[float] = []
+        batch_size = max(1, int(getattr(self, "_batch_size", RERANK_BATCH_SIZE)))
+        for start in range(0, len(pairs), batch_size):
+            batch_pairs = pairs[start : start + batch_size]
+            encoded = tokenizer(
+                batch_pairs,
+                padding=True,
+                truncation=True,
+                max_length=512,
+                return_tensors="pt"
+            )
+            with torch.inference_mode():
+                outputs = model(**encoded)
+            logits = getattr(outputs, "logits", None)
+            if logits is None:
+                all_scores.extend([0.0 for _ in batch_pairs])
+                continue
+            flat = logits.squeeze(-1).detach().cpu().tolist()
+            if isinstance(flat, float):
+                all_scores.append(float(flat))
+            else:
+                all_scores.extend(float(v) for v in flat)
+        return all_scores
 
 
 @dataclass
@@ -152,10 +162,11 @@ class Retriever:
             return []
 
         query_embedding = self._calculate_query_embedding(RETRIEVAL_QUERY_PREFIX + normalized_query)
+        initial_limit = max(top_k, min(max(self.initial_limit, top_k), MAX_INITIAL_RETRIEVAL_LIMIT))
         candidates = self.persistence.search(
             query_embedding=query_embedding,
             query_text=normalized_query,
-            limit=max(self.initial_limit, top_k),
+            limit=initial_limit,
             repo=repo,
             branch=branch,
         )

--- a/packages/core/src/constants.py
+++ b/packages/core/src/constants.py
@@ -15,6 +15,8 @@ DEFAULT_RERANK_TASK_INSTRUCTION = os.getenv("rerank_instruction","Given a search
 DEFAULT_ATTN_IMPLEMENTATION = "sdpa"
 DEFAULT_TOP_K = int(os.getenv("topk", 10))
 DEFAULT_INITIAL_RETRIEVAL_LIMIT = DEFAULT_TOP_K * 10
+MAX_INITIAL_RETRIEVAL_LIMIT = int(os.getenv("max_initial_limit", 50))
+RERANK_BATCH_SIZE = int(os.getenv("rerank_batch_size", 8))
 
 # Persistence constants
 DEFAULT_TABLE_NAME = "chunks"

--- a/packages/core/tests/test_libsql_persist.py
+++ b/packages/core/tests/test_libsql_persist.py
@@ -113,6 +113,32 @@ class LibsqlPersistenceTests(unittest.TestCase):
             ).scalar_one()
             self.assertEqual(fts_remaining, 0)
 
+    def test_search_includes_vector_only_candidates(self) -> None:
+        keyword_chunk = _build_chunk(self.repo, "src/keyword.py")
+        object.__setattr__(keyword_chunk, "chunk", "keywordmatch")
+        vector_chunk = _build_chunk(self.repo, "src/vector.py")
+        vec = array("f", [0.0] * 768)
+        vec[1] = 1.0
+        object.__setattr__(vector_chunk, "embeddings", vec.tobytes())
+        object.__setattr__(vector_chunk, "chunk", "different text")
+        self.adapter.persist_batch([keyword_chunk, vector_chunk])
+
+        query_vec = array("f", [0.0] * 768)
+        query_vec[1] = 1.0
+        out = self.adapter.search(query_vec, "keywordmatch", limit=2, repo=self.repo)
+
+        paths = {chunk.path for chunk in out}
+        self.assertIn("src/keyword.py", paths)
+        self.assertIn("src/vector.py", paths)
+
+    def test_search_handles_special_characters_in_fts_query(self) -> None:
+        chunk = _build_chunk(self.repo, "src/special.py")
+        self.adapter.persist_batch([chunk])
+        query_vec = array("f", [0.0] * 768)
+        query_vec[0] = 1.0
+        out = self.adapter.search(query_vec, 'foo-(bar) "baz"*', limit=1, repo=self.repo)
+        self.assertIsInstance(out, list)
+
 
 class GetIndexedPathsTests(unittest.TestCase):
     """Unit tests for PersistInLibsql.get_indexed_paths using mocks (no real DB)."""

--- a/packages/mcp-server/src/gitrag_mcp_server/server.py
+++ b/packages/mcp-server/src/gitrag_mcp_server/server.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 import os
 from dataclasses import asdict
 from typing import Any
+import logging
 
 from fastmcp import FastMCP
 from fastmcp.server.auth import TokenVerifier
 from fastmcp.server.auth.providers.scalekit import ScalekitProvider
 
+logger = logging.getLogger(__name__)
 
 class _RetrieverProtocol:
     def retrieve(
@@ -59,9 +61,16 @@ def create_mcp_server(
     retriever: _RetrieverProtocol,
     token_verifier: TokenVerifier | None = None,
     base_url: str | None = None,
+    require_auth: bool = True,
 ) -> FastMCP:
     """Create an authenticated MCP server with `search_code` tool."""
-    auth_provider = build_scalekit_provider(token_verifier=token_verifier, base_url=base_url)
+    auth_provider = None
+    try:
+        auth_provider = build_scalekit_provider(token_verifier=token_verifier, base_url=base_url)
+    except RuntimeError:
+        if require_auth:
+            raise
+        logger.warning("Scalekit not configured; creating MCP server without authentication")
     mcp = FastMCP(name="GitRag MCP Server", auth=auth_provider)
 
     @mcp.tool(name="search_code")
@@ -70,16 +79,24 @@ def create_mcp_server(
         top_k: int = 5,
         repo: str | None = None,
         branch: str | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> dict[str, Any]:
         """Search indexed code and return top snippets."""
         chunks = retriever.retrieve(query, top_k=top_k, repo=repo, branch=branch)
         output: list[dict[str, Any]] = []
+        markdown_blocks: list[str] = []
         for chunk in chunks:
             payload = asdict(chunk)
             embeddings = payload.get("embeddings")
             if isinstance(embeddings, (bytes, bytearray, memoryview)):
                 payload["embeddings"] = None
+            payload["formatted"] = (
+                f'<file path="{payload.get("path")}" repo="{payload.get("repo")}" '
+                f'branch="{payload.get("branch")}">\n{payload.get("chunk", "")}\n</file>'
+            )
+            markdown_blocks.append(
+                f"### {payload.get('path')}\n\n```{payload.get('language', '')}\n{payload.get('chunk', '')}\n```"
+            )
             output.append(payload)
-        return output
+        return {"results": output, "markdown": "\n\n".join(markdown_blocks)}
 
     return mcp

--- a/packages/mcp-server/src/gitrag_mcp_server/server.py
+++ b/packages/mcp-server/src/gitrag_mcp_server/server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import asdict
+from html import escape
 from typing import Any
 import logging
 
@@ -89,9 +90,13 @@ def create_mcp_server(
             embeddings = payload.get("embeddings")
             if isinstance(embeddings, (bytes, bytearray, memoryview)):
                 payload["embeddings"] = None
+            escaped_path = escape(str(payload.get("path", "")), quote=True)
+            escaped_repo = escape(str(payload.get("repo", "")), quote=True)
+            escaped_branch = escape(str(payload.get("branch", "")), quote=True)
+            escaped_chunk = escape(str(payload.get("chunk", "")))
             payload["formatted"] = (
-                f'<file path="{payload.get("path")}" repo="{payload.get("repo")}" '
-                f'branch="{payload.get("branch")}">\n{payload.get("chunk", "")}\n</file>'
+                f'<file path="{escaped_path}" repo="{escaped_repo}" '
+                f'branch="{escaped_branch}">\n{escaped_chunk}\n</file>'
             )
             markdown_blocks.append(
                 f"### {payload.get('path')}\n\n```{payload.get('language', '')}\n{payload.get('chunk', '')}\n```"

--- a/packages/mcp-server/tests/test_server.py
+++ b/packages/mcp-server/tests/test_server.py
@@ -110,9 +110,12 @@ def test_search_code_tool_with_authenticated_request(scalekit_env):
 
     assert result.is_error is False
     assert isinstance(result.structured_content, dict)
-    chunks = result.structured_content["result"]
+    payload = result.structured_content
+    chunks = payload["results"]
     assert chunks[0]["path"] == "src/main.py"
     assert chunks[0]["embeddings"] is None
+    assert "<file path=" in chunks[0]["formatted"]
+    assert "```python" in payload["markdown"]
     assert retriever.calls == [("needle", 3, None, None)]
 
 
@@ -141,3 +144,11 @@ def test_search_code_tool_rejects_invalid_token(scalekit_env):
 
     server.should_exit = True
     thread.join(timeout=2)
+
+
+def test_create_server_without_scalekit_when_auth_optional(monkeypatch):
+    monkeypatch.delenv("SCALEKIT_ENVIRONMENT_URL", raising=False)
+    monkeypatch.delenv("SCALEKIT_CLIENT_ID", raising=False)
+    monkeypatch.delenv("SCALEKIT_RESOURCE_ID", raising=False)
+    server = create_mcp_server(retriever=FakeRetriever(), require_auth=False)
+    assert server is not None

--- a/packages/mcp-server/tests/test_server.py
+++ b/packages/mcp-server/tests/test_server.py
@@ -152,3 +152,48 @@ def test_create_server_without_scalekit_when_auth_optional(monkeypatch):
     monkeypatch.delenv("SCALEKIT_RESOURCE_ID", raising=False)
     server = create_mcp_server(retriever=FakeRetriever(), require_auth=False)
     assert server is not None
+
+
+def test_search_code_tool_formats_xml_safely():
+    class SpecialRetriever(FakeRetriever):
+        def retrieve(self, query: str, *, top_k: int = 10, repo: str | None = None, branch: str | None = None):
+            return [
+                FakeChunk(
+                    chunk='if x < y: print("a & b")',
+                    repo='repo"1',
+                    path='src/"weird".py',
+                    language="python",
+                    start_rc=(1, 0),
+                    end_rc=(1, 10),
+                    start_bytes=0,
+                    end_bytes=10,
+                )
+            ]
+
+    mcp = create_mcp_server(
+        retriever=SpecialRetriever(),
+        base_url="http://127.0.0.1:8768/mcp",
+        require_auth=False,
+    )
+    app = mcp.http_app(path="/mcp", transport="streamable-http")
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=8768, log_level="error")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=_run_server, args=(server,), daemon=True)
+    thread.start()
+    time.sleep(0.8)
+
+    async def _call_tool():
+        client = Client("http://127.0.0.1:8768/mcp")
+        async with client:
+            return await client.call_tool("search_code", {"query": "x"})
+
+    response = asyncio.run(_call_tool())
+    server.should_exit = True
+    thread.join(timeout=2)
+
+    assert response.is_error is False
+    formatted = response.structured_content["results"][0]["formatted"]
+    assert 'path="src/&quot;weird&quot;.py"' in formatted
+    assert 'repo="repo&quot;1"' in formatted
+    assert "if x &lt; y: print(&quot;a &amp; b&quot;)" in formatted

--- a/provisioning/libsql/schema.sql
+++ b/provisioning/libsql/schema.sql
@@ -26,6 +26,6 @@ CREATE INDEX IF NOT EXISTS chunks_path_idx ON chunks (path);
 CREATE INDEX IF NOT EXISTS chunks_repo_path_idx ON chunks (repo, path);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
-  id UNINDEXED,
+  id,
   chunk
 );


### PR DESCRIPTION
### Motivation
- Fix a fundamentally broken libSQL hybrid search that dropped semantically relevant vector matches by first filtering strictly by FTS and only then scoring vectors.
- Make FTS usage robust against user queries containing special characters that crash SQLite FTS5, and avoid unindexed FTS deletions that cause full table scans.
- Reduce memory/time pressure on low-resource environments by batching embedding and reranker inference and by capping initial candidate limits.
- Allow running the MCP server locally without Scalekit for development and produce LLM-friendly, token-efficient formatted search results.

### Description
- Reworked libSQL search to perform a true hybrid search by independently fetching keyword candidates (`_keyword_search`) and vector candidates (`_vector_search`), merging them by `id`, and applying Reciprocal Rank Fusion (RRF) to combine keyword and vector rankings; this prevents high-similarity vector matches from being lost by keyword prefiltering (`packages/core/src/Persistence/Persist.py`).
- Sanitized libSQL FTS input via `_safe_fts_query` that extracts safe tokens and builds an OR expression for `MATCH`, and retained a safe `LIKE` fallback when FTS cannot be used; also ensured returned rows include both `keyword_score` and `vector_score` fields for merged ranking logic (`packages/core/src/Persistence/Persist.py`).
- Updated libSQL provisioning schema so the FTS table includes an indexed `id` column (removed `UNINDEXED`) to avoid pathological full-table scans on deletes (`provisioning/libsql/schema.sql`).
- Bounded embedding and reranker workloads by chunking `EmbeddingCalculator.calculate_batch` using `EMBEDDING_BATCH_SIZE`, adding `RERANK_BATCH_SIZE` and micro-batching in `Qwen3Reranker.score`, and capping the retrieval initial limit with `MAX_INITIAL_RETRIEVAL_LIMIT` to reduce OOM/timeouts on constrained hosts (`packages/core/src/Calculators/EmbeddingCalculator.py`, `packages/core/src/Retriever.py`, `packages/core/src/constants.py`).
- Made MCP server auth optional via `require_auth=False` for local/dev workflows and changed `search_code` output to return a structured response with `results` (payloads include a compact `formatted` XML-like snippet) and an aggregated `markdown` string for LLM-friendly contexts; updated tests accordingly (`packages/mcp-server/src/gitrag_mcp_server/server.py`, `packages/mcp-server/tests/test_server.py`).
- Added unit tests covering vector-only candidate inclusion and safe FTS handling for libSQL, plus adjusted MCP server tests to the new response shape and optional-auth behavior (`packages/core/tests/test_libsql_persist.py`, `packages/mcp-server/tests/test_server.py`).

### Testing
- Ran core persistence and retriever tests with `PYTEST_ADDOPTS='' pytest -c pyproject.toml packages/core/tests/test_libsql_persist.py packages/core/tests/test_retriever.py`, and all tests passed (`18 passed`).
- Ran MCP server tests with `PYTEST_ADDOPTS='' PYTHONPATH=packages/mcp-server/src pytest -c pyproject.toml packages/mcp-server/tests/test_server.py`, and all tests passed (`5 passed`).
- Commits include the changes and tests referenced above; automated test runs shown in the rollout succeeded as noted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1c81c76dc8333be168fdc54f41e15)